### PR TITLE
Refactor auto-scheduler and fix time display bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -1079,8 +1079,9 @@
         function minutesToTime(totalMinutes) {
             if (isNaN(totalMinutes) || totalMinutes < 0) return 'Invalid';
             
-            const hours = Math.floor(totalMinutes / 60);
-            const minutes = Math.round(totalMinutes % 60);
+            const roundedTotalMinutes = Math.round(totalMinutes);
+            const hours = Math.floor(roundedTotalMinutes / 60);
+            const minutes = roundedTotalMinutes % 60;
             const period = hours >= 12 ? 'PM' : 'AM';
             let displayHours = hours % 12;
             if (displayHours === 0) displayHours = 12;
@@ -1737,10 +1738,47 @@
             state.draggedPatient = null;
         }
 
-        // Enhanced auto-scheduling
+        // Determines available time slots based on fixed schedule items like breaks and tasks.
+        function getScheduleGaps() {
+            const dayStartMins = timeStringToMinutes(state.settings.workDay.startTime);
+            const scheduledBlocks = [
+                ...state.settings.breaks.map(b => ({
+                    start: timeStringToMinutes(b.start),
+                    end: timeStringToMinutes(b.end)
+                })),
+                ...state.settings.otherTasks.map(t => ({
+                    start: timeStringToMinutes(t.start),
+                    end: timeStringToMinutes(t.end)
+                }))
+            ].sort((a, b) => a.start - b.start);
+
+            const gaps = [];
+            let lastEnd = dayStartMins + state.settings.setupTime;
+
+            scheduledBlocks.forEach(block => {
+                if (block.start > lastEnd) {
+                    gaps.push({ start: lastEnd, end: block.start });
+                }
+                lastEnd = Math.max(lastEnd, block.end);
+            });
+
+            const dayEndMins = dayStartMins + 12 * 60; // 12-hour workday limit
+            if (dayEndMins > lastEnd) {
+                gaps.push({ start: lastEnd, end: dayEndMins });
+            }
+
+            return gaps.map(g => ({...g, duration: g.end - g.start})).filter(g => g.duration > 0);
+        }
+
+        // Enhanced auto-scheduling with best-fit algorithm
         function autoSchedule() {
-            if (state.patientQueue.length === 0) {
-                showAlert('No patients in queue to schedule', 'warning');
+            const patientsToSchedule = [
+                ...state.patientQueue,
+                ...state.appointments.map(a => ({ id: a.id, name: a.name, duration: a.duration }))
+            ];
+
+            if (patientsToSchedule.length === 0) {
+                showAlert('No patients to schedule', 'warning');
                 return;
             }
             
@@ -1750,83 +1788,73 @@
             
             setTimeout(() => {
                 try {
-                    const allPatients = [...state.patientQueue, ...state.appointments.map(a => ({ 
-                        id: a.id, name: a.name, duration: a.duration 
-                    }))];
-                    
-                    allPatients.sort((a, b) => b.duration - a.duration);
+                    // 1. Sort all patients by duration, largest first
+                    patientsToSchedule.sort((a, b) => b.duration - a.duration);
                     
                     state.patientQueue = [];
                     state.appointments = [];
 
-                    const dayStartMins = timeStringToMinutes(state.settings.workDay.startTime);
-
-                    const unavailableBlocks = [
-                        ...state.settings.breaks.map(b => ({ 
-                            start: timeStringToMinutes(b.start), 
-                            end: timeStringToMinutes(b.end) 
-                        })),
-                        ...state.settings.otherTasks.map(t => ({ 
-                            start: timeStringToMinutes(t.start), 
-                            end: timeStringToMinutes(t.end) 
-                        }))
-                    ].sort((a, b) => a.start - b.start);
-
-                    let currentTime = dayStartMins + state.settings.setupTime;
+                    // 2. Get initial available gaps based on breaks/tasks
+                    let availableGaps = getScheduleGaps();
                     let scheduledCount = 0;
 
-                    allPatients.forEach(patient => {
-                        let placed = false;
-                        let attempts = 0;
-                        const maxAttempts = 50;
-                        
-                        while (!placed && attempts < maxAttempts) {
-                            let availableSlot = true;
-                            const potentialEndTime = currentTime + patient.duration;
+                    // 3. Place patients using a best-fit approach
+                    patientsToSchedule.forEach(patient => {
+                        // Find the smallest gap that fits the patient (best-fit)
+                        let bestGapIndex = -1;
+                        let minViableGapSize = Infinity;
 
-                            if (potentialEndTime > dayStartMins + 12 * 60) { // 12 hour limit
-                                state.patientQueue.push(patient);
-                                break;
+                        availableGaps.forEach((gap, index) => {
+                            if (gap.duration >= patient.duration && gap.duration < minViableGapSize) {
+                                minViableGapSize = gap.duration;
+                                bestGapIndex = index;
                             }
+                        });
 
-                            for (const block of unavailableBlocks) {
-                                if ((currentTime >= block.start && currentTime < block.end) || 
-                                    (potentialEndTime > block.start && potentialEndTime <= block.end) || 
-                                    (currentTime < block.start && potentialEndTime > block.end)) {
-                                    currentTime = block.end;
-                                    availableSlot = false;
-                                    break;
-                                }
-                            }
+                        if (bestGapIndex !== -1) {
+                            const gapToFill = availableGaps[bestGapIndex];
 
-                            if (availableSlot) {
-                                const startTime = minutesToTime(currentTime);
-                                const endTime = minutesToTime(potentialEndTime);
-                                
-                                state.appointments.push({
-                                    id: patient.id,
-                                    name: patient.name,
-                                    duration: patient.duration,
-                                    start: startTime.slice(0, -2),
-                                    startPeriod: startTime.slice(-2),
-                                    end: endTime.slice(0, -2),
-                                    endPeriod: endTime.slice(-2),
-                                    completed: false
-                                });
-                                
-                                currentTime += patient.duration + state.settings.transitionTime;
-                                scheduledCount++;
-                                placed = true;
+                            // Place patient at the start of the chosen gap
+                            const startTime = minutesToTime(gapToFill.start);
+                            const endTime = minutesToTime(gapToFill.start + patient.duration);
+
+                            state.appointments.push({
+                                id: patient.id,
+                                name: patient.name,
+                                duration: patient.duration,
+                                start: startTime.slice(0, -2),
+                                startPeriod: startTime.slice(-2),
+                                end: endTime.slice(0, -2),
+                                endPeriod: endTime.slice(-2),
+                                completed: false
+                            });
+
+                            // Update the gap: reduce its size and move its start time
+                            const remainingDuration = gapToFill.duration - patient.duration - state.settings.transitionTime;
+
+                            if (remainingDuration >= 15) { // Minimum schedulable duration
+                                gapToFill.start += patient.duration + state.settings.transitionTime;
+                                gapToFill.duration = remainingDuration;
+                            } else {
+                                // Remove the gap if it's too small to be useful
+                                availableGaps.splice(bestGapIndex, 1);
                             }
-                            attempts++;
+                            scheduledCount++;
+                        } else {
+                            // If no suitable gap is found, return patient to the queue
+                            state.patientQueue.push(patient);
                         }
                     });
 
+                    // Sort final appointments by time for chronological rendering
+                    state.appointments.sort((a, b) =>
+                        timeToMinutes24h(a.start + a.startPeriod) - timeToMinutes24h(b.start + b.startPeriod)
+                    );
+
                     renderPatientQueue();
-                    renderTimeline();
-                    calculateSchedule();
+                    calculateSchedule(); // This will also render the timeline
                     
-                    showAlert(`Auto-scheduling complete! ${scheduledCount} patients scheduled, ${state.patientQueue.length} remain in queue`, 'success', 3000);
+                    showAlert(`Auto-scheduling complete! ${scheduledCount} patients scheduled, ${state.patientQueue.length} remain in queue.`, 'success', 3000);
                 } catch (error) {
                     console.error('Auto-scheduling error:', error);
                     showAlert('Error during auto-scheduling. Please try again.', 'error');


### PR DESCRIPTION
This commit introduces two main improvements to the therapy scheduler:

1.  **Refactors the `autoSchedule` algorithm:** The previous scheduling logic was a simple sequential placement algorithm that could leave viable gaps in the schedule. The new implementation uses a "best-fit" approach. It first identifies all available time slots and then places patients into the smallest viable gap, resulting in a more compact and efficient schedule. A `getScheduleGaps` helper function was added to improve modularity.

2.  **Fixes a time display bug in `minutesToTime`:** The `minutesToTime` function would previously produce invalid time displays (e.g., "8:60 PM") when calculations resulted in fractional minutes. The function has been corrected to round the total minutes *before* converting to an HH:MM format, ensuring the output is always a valid time.