### PR TITLE
fix: Prevent duplicate event listeners on re-render

### DIFF
--- a/index.html
+++ b/index.html
@@ -286,8 +286,7 @@
             renderDaySummary(schedule, appointments, patientQueue, settings);
             renderScheduleTimeline(schedule, settings);
             
-            // Add event listeners
-            addEventListeners();
+            // Event listeners are now attached once in init()
         }
 
         // --- EVENT HANDLERS & LOGIC ---
@@ -542,6 +541,7 @@
                 console.error("Failed to load from localStorage", e);
                 setNotification("Could not load saved settings.", 'error');
             }
+            addEventListeners(); // Attach event listeners once
             render();
         }
 


### PR DESCRIPTION
The application was attaching new event listeners on every `render()` call, which caused handlers to fire multiple times for a single event (e.g., clicking a preset button would add multiple patients).

This is fixed by refactoring the initialization logic. The `addEventListeners()` function is now called only once when the application starts up in the `init()` function, instead of being called inside the `render()` loop. This ensures that a single set of event listeners is attached to the root element, which correctly handles events for all dynamically created child elements via delegation.