### PR TITLE
Fix visual schedule overlap and clock time updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,14 +150,19 @@
              const allScheduledItems = [
                 ...state.settings.breaks.map(b => ({ ...b, type: 'break', startMins: timeStringToMinutes(b.start), endMins: timeStringToMinutes(b.end) })),
                 ...state.settings.otherTasks.map(t => ({ ...t, type: t.type, startMins: timeStringToMinutes(t.start), endMins: timeStringToMinutes(t.end) })),
-                ...state.appointments.map(a => ({ ...a, type: 'appointment', startMins: timeToMinutes(a.start, a.startPeriod), endMins: timeToMinutes(a.end, a.endPeriod) + (a.type === 'appointment' ? state.settings.transitionTime : 0) }))
+                ...state.appointments.map(a => {
+                    const startMins = timeToMinutes(a.start, a.startPeriod);
+                    const endMins = startMins + a.duration;
+                    return { ...a, type: 'appointment', startMins, endMins };
+                })
             ].sort((a, b) => a.startMins - b.startMins);
 
             const dayStartMins = timeStringToMinutes(state.settings.workDay.startTime);
             
             let lastEnd = dayStartMins + state.settings.setupTime;
             allScheduledItems.forEach(item => {
-                lastEnd = Math.max(lastEnd, item.endMins);
+                const effectiveEndMins = item.type === 'appointment' ? item.endMins + state.settings.transitionTime : item.endMins;
+                lastEnd = Math.max(lastEnd, effectiveEndMins);
             });
 
             // Calculate Gaps between items
@@ -167,7 +172,8 @@
                 if (item.startMins > lastGapCheck) {
                     gaps.push({ id: `gap-${lastGapCheck}`, start: lastGapCheck, end: item.startMins, duration: item.startMins - lastGapCheck, type: 'gap' });
                 }
-                lastGapCheck = Math.max(lastGapCheck, item.endMins);
+                const effectiveEndMins = item.type === 'appointment' ? item.endMins + state.settings.transitionTime : item.endMins;
+                lastGapCheck = Math.max(lastGapCheck, effectiveEndMins);
             });
 
             // Productivity Calculations
@@ -402,7 +408,7 @@
                 const fixedEvents = [
                     ...state.settings.breaks.map(b => ({ start: timeStringToMinutes(b.start), end: timeStringToMinutes(b.end) })),
                     ...state.settings.otherTasks.map(t => ({ start: timeStringToMinutes(t.start), end: timeStringToMinutes(t.end) })),
-                    ...currentAppointments.map(a => ({ start: timeToMinutes(a.start, a.startPeriod), end: timeToMinutes(a.end, a.endPeriod) + state.settings.transitionTime }))
+                    ...currentAppointments.map(a => ({ start: timeToMinutes(a.start, a.startPeriod), end: timeToMinutes(a.start, a.startPeriod) + a.duration + state.settings.transitionTime }))
                 ].sort((a,b) => a.start - b.start);
 
                 const gaps = [];


### PR DESCRIPTION
The visual scheduler had two primary issues: session blocks would overlap, and their clock times would not update when the session duration was edited.

This was caused by the rendering logic incorrectly including the separate 'transition time' in the visual size of the appointment block. The end time was also being read from a stored property that didn't always reflect the latest duration change.

This commit refactors the scheduling logic to use an appointment's `duration` property as the single source of truth for its length.

- The `calculateScheduleMetrics` function now calculates an appointment's visual end time based on `startTime + duration`. The `transitionTime` is now handled separately when calculating gaps between items, preventing visual overlap.
- The `autoSchedule` function has been updated to use the same duration-based calculation for consistency.

These changes resolve both reported issues, making the scheduler's behavior correct and intuitive.