### PR TITLE
Fix: Repair Settings Panel and Finalize UI Update

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,11 +140,7 @@
             isEditModalOpen: false,
             editingAppointment: null,
             draggedPatient: null,
-            patientCounter: 1,
-            ui: {
-                isBreaksPanelOpen: true,
-                isTasksPanelOpen: false,
-            }
+            patientCounter: 1
         };
 
         // --- HELPER FUNCTIONS ---
@@ -778,8 +774,8 @@
         function renderSettingsPanel(settings) {
             const container = document.getElementById('settings-panel-container');
             container.innerHTML = `
-                <details class="bg-gray-800 rounded-lg shadow-lg p-4 border border-gray-700" ${state.ui.isBreaksPanelOpen ? 'open' : ''}>
-                    <summary class="font-semibold text-xl text-gray-200 cursor-pointer" data-panel-id="breaks">Work Day & Breaks</summary>
+                <details class="bg-gray-800 rounded-lg shadow-lg p-4 border border-gray-700" open>
+                    <summary class="font-semibold text-xl text-gray-200 cursor-pointer">Work Day & Breaks</summary>
                     <div class="mt-4 space-y-4">
                         <div>
                             <h3 class="font-semibold text-gray-400 mb-2">Work Start Time</h3>
@@ -803,8 +799,8 @@
                         </div>
                     </div>
                 </details>
-                <details class="bg-gray-800 rounded-lg shadow-lg p-4 border border-gray-700" ${state.ui.isTasksPanelOpen ? 'open' : ''}>
-                    <summary class="font-semibold text-xl text-gray-200 cursor-pointer" data-panel-id="tasks">Other Tasks & Settings</summary>
+                <details class="bg-gray-800 rounded-lg shadow-lg p-4 border border-gray-700">
+                    <summary class="font-semibold text-xl text-gray-200 cursor-pointer">Other Tasks & Settings</summary>
                     <div class="mt-4 space-y-4">
                         <div>
                             <h3 class="font-semibold text-gray-400 mb-2">Other Scheduled Tasks</h3>
@@ -1123,19 +1119,6 @@
 
         // --- DELEGATED EVENT HANDLERS ---
         function handleRootClick(e) {
-            const summary = e.target.closest('summary');
-            if (summary) {
-                e.preventDefault(); // Stop the default browser toggle
-                const panelId = summary.dataset.panelId;
-                if (panelId === 'breaks') {
-                    state.ui.isBreaksPanelOpen = !state.ui.isBreaksPanelOpen;
-                } else if (panelId === 'tasks') {
-                    state.ui.isTasksPanelOpen = !state.ui.isTasksPanelOpen;
-                }
-                render();
-                return;
-            }
-
             const btn = e.target.closest('button');
             if (!btn) return;
 


### PR DESCRIPTION
This commit resolves a bug that caused the settings panels ('Work Day & Breaks' and 'Other Tasks & Settings') to be non-functional. The issue was caused by custom JavaScript that interfered with the native behavior of the `<details>` HTML element.

The fix involves:
- Removing the custom click handler that was intercepting events on the `<summary>` element.
- Deleting the unnecessary `ui` state object that was tracking the open/closed state of the panels.
- Updating the `renderSettingsPanel` function to remove the conditional logic for the `open` attribute, allowing the browser to manage the state natively.

This change ensures that the settings panels are now fully functional and behave as expected. The rest of the application's updated UI and features remain intact.